### PR TITLE
performance.timing is deprecated

### DIFF
--- a/index.html
+++ b/index.html
@@ -1265,15 +1265,12 @@ or is not completed.</p>
   <dd><p>Any navigation types not defined by values above.</p></dd>
 
 <dt>readonly attribute unsigned long long type</dt>
-  <dt>serializer = { attribute }</dt>
 <dd>
 
 <p>This attribute must return the type of the last non-redirect <a
 href="http://www.w3.org/TR/html5/browsers.html#navigate">navigation</a>
 in the current browsing context. It must have one of the following <a
 href="#widl-PerformanceNavigation-type">navigation type</a> values. </p>
-<dl>
-</dl>
 
 <p class="note">Client-side redirects, such as those using <a href="hhttp://www.w3.org/TR/html5/document-metadata.html#attr-meta-http-equiv-refresh">the Refresh pragma directive</a>,
 are not considered HTTP redirects <a href="http://www.w3.org/TR/html5/infrastructure.html#concept-http-equivalent-codes">or equivalent</a> by this spec.
@@ -1291,6 +1288,7 @@ redirect or there is any redirect that is not from the same
 <a href="http://tools.ietf.org/html/rfc6454">
 origin</a> as the destination document, this attribute must return zero. </p>
 </dd>
+<dt>serializer = { attribute }</dt>
 </dl>
 
 </section>

--- a/index.html
+++ b/index.html
@@ -856,8 +856,9 @@ non-normative intervals between timings.
         <a href="#widl-PerformanceNavigationTiming-redirectEnd">redirectEnd</a>,
         <a href="#widl-PerformanceNavigationTiming-redirectCount">redirectCount</a>,
         <a href="#widl-PerformanceNavigationTiming-type">type</a>,
+        <a href="#widl-PerformanceNavigationTiming-nextHopProtocol">nextHopProtocol</a>,
         <a href="#widl-PerformanceNavigationTiming-unloadEventStart">unloadEventStart</a> and
-        <a href="#widl-PerformanceNavigationTiming-unloadEventEnd">unloadEventEnd</a>.</li>
+        <a href="#widl-PerformanceNavigationTiming-unloadEventEnd">unloadEventEnd</a>. Set <a href="#widl-PerformanceNavigationTiming-nextHopProtocol">nextHopProtocol</a> to the empty <code>DOMString</code>.</li>
       <li>Return to step <a href="#step-fetch-start">9</a> with the new resource.</li>
     </ol>
   </li>

--- a/index.html
+++ b/index.html
@@ -850,10 +850,12 @@ non-normative intervals between timings.
         let it be the value of <a href="#widl-PerformanceNavigationTiming-fetchStart">fetchStart</a>.</li>
       <li>Let <a href="#widl-PerformanceNavigationTiming-redirectEnd">redirectEnd</a> be the value of
         <a href="#widl-PerformanceNavigationTiming-responseEnd">responseEnd</a>.</li>
-      <li>Set all the attributes in window.performance.timing to 0 except
+      <li>Set all of the attributes in the <a>PerformanceNavigationTiming</a> object to 0 except
         <a href="#widl-PerformanceNavigationTiming-startTime">startTime</a>,
         <a href="#widl-PerformanceNavigationTiming-redirectStart">redirectStart</a>,
         <a href="#widl-PerformanceNavigationTiming-redirectEnd">redirectEnd</a>,
+        <a href="#widl-PerformanceNavigationTiming-redirectCount">redirectCount</a>,
+        <a href="#widl-PerformanceNavigationTiming-type">type</a>,
         <a href="#widl-PerformanceNavigationTiming-unloadEventStart">unloadEventStart</a> and
         <a href="#widl-PerformanceNavigationTiming-unloadEventEnd">unloadEventEnd</a>.</li>
       <li>Return to step <a href="#step-fetch-start">9</a> with the new resource.</li>


### PR DESCRIPTION
Attempting to fix the processing model #15 

Should we reset nextHopProtocol to the empty string before jumping back to step 9?