### PR TITLE
fix: missing timestamp-diagram.svg

### DIFF
--- a/W3CTRMANIFEST
+++ b/W3CTRMANIFEST
@@ -1,1 +1,2 @@
 index.html?specStatus=WD;shortName=navigation-timing-2;useExperimentalStyles=false respec
+timestamp-diagram.svg


### PR DESCRIPTION
This makes sure the svg file actually gets copied over the TR. It's currently missing there.