### PR TITLE
Register entry type "navigation"

### DIFF
--- a/index.html
+++ b/index.html
@@ -278,6 +278,12 @@
           respectively.
           </li>
         </ul>
+        <p>
+          A user agent implementing <a>PerformanceNavigationTiming</a> MUST run the
+          <a data-cite="PERFORMANCE-TIMELINE-2#dfn-register-a-performance-entry-type">
+          register a performance entry type</a> algorithm with <code>"navigation"</code>
+          as input.
+        </p>
       </section>
       <section id='PerformanceResourceTiming'>
         <h3>


### PR DESCRIPTION
This change adds the call to register the "navigation" entryType.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/npm1/navigation-timing/pull/98.html" title="Last updated on Nov 29, 2018, 11:24 PM GMT (f434bc4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/navigation-timing/98/2110af2...npm1:f434bc4.html" title="Last updated on Nov 29, 2018, 11:24 PM GMT (f434bc4)">Diff</a>