### PR TITLE
supported entry types needs to be context aware

### DIFF
--- a/index.html
+++ b/index.html
@@ -279,10 +279,7 @@
           </li>
         </ul>
         <p>
-          A user agent implementing <a>PerformanceNavigationTiming</a> MUST run the
-          <a data-cite="PERFORMANCE-TIMELINE-2#dfn-register-a-performance-entry-type">
-          register a performance entry type</a> algorithm with <code>"navigation"</code>
-          as input.
+          If the <dfn data-cite="HTML#concept-settings-object-global">global object</dfn> is a <a data-cite="HTML#window">Window</a> object, a user agent implementing <a>PerformanceNavigationTiming</a> MUST run the <a data-cite="PERFORMANCE-TIMELINE-2#dfn-register-a-performance-entry-type"> register a performance entry type</a> algorithm with <code>"navigation"</code> and the <a>global object</a> as input.
         </p>
       </section>
       <section id='PerformanceResourceTiming'>


### PR DESCRIPTION
Fixes https://github.com/w3c/navigation-timing/issues/102.

I will fix the line breaks when the verbiage is approved.

Accompanying [performance-timeline](https://github.com/w3c/performance-timeline/pull/121) change.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cvazac/navigation-timing/pull/105.html" title="Last updated on Mar 29, 2019, 1:05 PM UTC (52032ee)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/navigation-timing/105/0c18edd...cvazac:52032ee.html" title="Last updated on Mar 29, 2019, 1:05 PM UTC (52032ee)">Diff</a>