### PR TITLE
Avoid redefining secureConnectionStart

### DIFF
--- a/index.html
+++ b/index.html
@@ -692,10 +692,10 @@
           If a connection can not be established, abort the rest of the
           steps.
         </li>
-        <p class=note>The <a data-cite=
+        <li>A user agent MUST also set the <a data-cite=
           "resource-timing-2#dom-performanceresourcetiming-secureconnectionstart">
-          <code>secureConnectionStart</code></a> attribute is defined
-          according to its processing model defined in [[RESOURCE-TIMING]].</p>
+          <code>secureConnectionStart</code></a> attribute as defined in the
+          attribute's processing model in [[RESOURCE-TIMING]].</li>
         <li id="request-start-step">
           <i>[request-start-step]</i> Immediately before a user agent starts
           sending request for the document, record the current time as

--- a/index.html
+++ b/index.html
@@ -696,21 +696,6 @@
           "resource-timing-2#dom-performanceresourcetiming-secureconnectionstart">
           <code>secureConnectionStart</code></a> attribute is defined
           according to its processing model defined in [[RESOURCE-TIMING]].</p>
-        <li>A user agent MUST also set the <a
-            data-cite="resource-timing-2#dom-performanceresourcetiming-secureconnectionstart">
-            <code>secureConnectionStart</code></a> attribute as follows:
-          <ol>
-            <li>When a secure transport is used, the user agent MUST record
-              the time as <a data-cite="resource-timing-2#dom-performanceresourcetiming-secureconnectionstart">
-                <code>secureConnectionStart</code></a> immediately before the
-              handshake process to secure the connection.
-            </li>
-            <li>When a secure transport is not used, the user agent MUST set
-              the value of <a data-cite="resource-timing-2#dom-performanceresourcetiming-secureconnectionstart">
-                <code>secureConnectionStart</code></a> to 0.
-            </li>
-          </ol>
-        </li>
         <li id="request-start-step">
           <i>[request-start-step]</i> Immediately before a user agent starts
           sending request for the document, record the current time as

--- a/index.html
+++ b/index.html
@@ -692,6 +692,10 @@
           If a connection can not be established, abort the rest of the
           steps.
         </li>
+        <p class=note>The <a data-cite=
+          "resource-timing-2#dom-performanceresourcetiming-secureconnectionstart">
+          <code>secureConnectionStart</code></a> attribute is defined
+          according to its processing model defined in [[RESOURCE-TIMING]].</p>
         <li>A user agent MUST also set the <a
             data-cite="resource-timing-2#dom-performanceresourcetiming-secureconnectionstart">
             <code>secureConnectionStart</code></a> attribute as follows:


### PR DESCRIPTION
Closes https://github.com/w3c/navigation-timing/issues/84


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoavweiss/navigation-timing/pull/106.html" title="Last updated on Jul 15, 2019, 1:52 PM UTC (f20ecdf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/navigation-timing/106/6188ea3...yoavweiss:f20ecdf.html" title="Last updated on Jul 15, 2019, 1:52 PM UTC (f20ecdf)">Diff</a>