### PR TITLE
remove jquery from spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
       background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' version='1.1' height='300px' width='125px'><text x='0' y='100' fill='red' font-size='15' fill-opacity='0.20'>Obsolete<\/text><\/svg>")
     }
   </style>
-  <script src='https://www.w3.org/Tools/respec/respec-w3c-common' async class='remove'></script>
+  <script src='https://www.w3.org/Tools/respec/respec-w3c' async class='remove'></script>
   <script class='remove'>
     var respecConfig = {
       shortName: "navigation-timing-2",
@@ -346,7 +346,7 @@
           <ol>
             <li>If there is no previous document, or if the <a>same-origin
               check</a> fails, return a {{DOMHighResTimeStamp}} with a time
-              value equal to zero.</li>    
+              value equal to zero.</li>
             <li>Otherwise, return a <a data-cite=
               "hr-time-2#dom-domhighrestimestamp">DOMHighResTimeStamp</a> with a
               time value equal to the time immediately before the user agent starts
@@ -361,7 +361,7 @@
           <ol>
             <li>If there is no previous document, or if the <a>same-origin
               check</a> fails, return a {{DOMHighResTimeStamp}} with a time
-              value equal to zero.</li>    
+              value equal to zero.</li>
             <li>Otherwise, return a {{DOMHighResTimeStamp}} with a time value
               equal to the time immediately before the user agent starts
               the <a data-cite=


### PR DESCRIPTION
@marcoscaceres mentioned that new specs should not use the `respec-w3c-common` profile because that profile uses JQuery and new specs should not need JQuery.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/janiceshiu/navigation-timing/pull/121.html" title="Last updated on Jan 21, 2020, 7:09 AM UTC (398a945)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/navigation-timing/121/ad54643...janiceshiu:398a945.html" title="Last updated on Jan 21, 2020, 7:09 AM UTC (398a945)">Diff</a>