### PR TITLE
Use real refs for DOM metrics

### DIFF
--- a/index.html
+++ b/index.html
@@ -397,30 +397,29 @@
         </ol>
         <p data-dfn-for='PerformanceNavigationTiming'>
          The <dfn>domInteractive</dfn> getter steps are to return
-         |this|'s [=document load timing=]'s <a data-cite="HTML#dom-interactive-time">DOM
-         interactive time</a>.</p>
+         |this|'s [=document load timing=]'s [=document load timing info/DOM interactive time=].</p>
 
         <p class="note">See <a data-cite=
           "HTML/dom.html#current-document-readiness">document readiness</a> for more info.
         </p>
         <p data-dfn-for='PerformanceNavigationTiming'>
          The <dfn>domContentLoadedEventStart</dfn> getter steps are to return |this|'s
-         [=document load timing=]'s <a data-cite="HTML#dom-content-loaded-event-end-time">DOM
-         content loaded event start time</a>.</p>
+         [=document load timing=]'s
+         [=document load timing info/DOM content loaded event start time=].</p>
         <p class="note">See <a data-cite=
           "HTML/parsing.html#the-end:event-domcontentloaded">DOMContentLoaded</a> for more info.
         </p>
         <p data-dfn-for='PerformanceNavigationTiming'>
          The <dfn>domContentLoadedEventEnd</dfn> getter steps are to return
-         |this|'s [=document load timing=]'s <a data-cite="HTML#dom-content-loaded-event-end-time">DOM
-         content loaded event end time</a>.</p>
+         |this|'s [=document load timing=]'s
+         [=document load timing info/DOM content loaded event end time=].</p>
+        <p class="note">See <a data-cite=
           "HTML/parsing.html#the-end:event-domcontentloaded">DOMContentLoaded
           event</a> completes.
         </p>
         <p data-dfn-for='PerformanceNavigationTiming'>
          The <dfn>domComplete</dfn> getter steps are to return
-         |this|'s [=document load timing=]'s <a data-cite="HTML#dom-complete-time">DOM complete
-         time</a>.
+         |this|'s [=document load timing=]'s [=document load timing info/DOM complete time=].
         <p class="note">See <a data-cite=
           "HTML/dom.html#current-document-readiness">document readiness</a> for more info.
         </p>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Apr 8, 2021, 1:57 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fw3c%2Fnavigation-timing%2F20af1c7ec17c175f6ad357b90da60275de719bde%2Findex.html%3FisPreview%3Dtrue)

```
📡 HTTP Error 429: https://rawcdn.githack.com/w3c/navigation-timing/20af1c7ec17c175f6ad357b90da60275de719bde/index.html
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/navigation-timing%23142.)._
</details>
