### PR TITLE
Integrate with service worker timing

### DIFF
--- a/index.html
+++ b/index.html
@@ -314,12 +314,10 @@
               <li>Return |workerTiming|'s [=service worker timing info/start time=].
             </ol>
           </li>
-          <li>The <dfn for="PerformanceNavigationTiming" id='dom-PerformanceNavigationTiming-fetchStart'><code>
-            fetchStart</code></dfn> getter steps</dfn> are to perform the following steps:
+          <li>The `fetchStart` getter steps are to perform the following steps:
             <ol>
               <li>Let |workerTiming| be |this|'s [=service worker timing=].
-              <li>If |workerTiming| is null, then return |this|'s
-              <a data-cite="resource-timing-2#dom-performanceresourcetiming-fetchstart">fetchStart</a>.
+              <li>If |workerTiming| is null, then return |this|'s `fetchStart`.
               <li>Return |workerTiming|'s [=service worker timing info/fetch event dispatch time=].
             </ol>
           </li>

--- a/index.html
+++ b/index.html
@@ -305,19 +305,22 @@
           "RESOURCE-TIMING-2#dom-performanceresourcetiming">PerformanceResourceTiming</dfn></code>
           interface:
         </p>
-        <ul data-dfn-for="PerformanceNavigationTiming">
-          <li>The <dfn id='dom-PerformanceNavigationTiming-workerStart'><code>
+        <ul>
+          <li>The <dfn for="PerformanceNavigationTiming" id='dom-PerformanceNavigationTiming-workerStart'><code>
             workerStart</code></dfn> getter steps are to perform the following steps:
             <ol>
               <li>Let |workerTiming| be |this|'s [=service worker timing=].
-              <li>If |workerTiming| is null, then return 0.
+              <li>If |workerTiming| is null, then return |this|'s
+              <a data-cite="resource-timing-2#dom-performanceresourcetiming-workerstart">workerStart</a>.
               <li>Return |workerTiming|'s [=service worker timing info/start time=].
             </ol>
           </li>
-          <li>The <dfn>`fetchStart` getter steps</dfn> are to perform the following steps:
+          <li>The <dfn for="PerformanceNavigationTiming" id='dom-PerformanceNavigationTiming-fetchStart'><code>
+            fetchStart</code></dfn> getter steps</dfn> are to perform the following steps:
             <ol>
               <li>Let |workerTiming| be |this|'s [=service worker timing=].
-              <li>If |workerTiming| is null, then return |this|'s {{PerformanceResourceTiming/fetchStart}}.
+              <li>If |workerTiming| is null, then return |this|'s
+              <a data-cite="resource-timing-2#dom-performanceresourcetiming-fetchstart">fetchStart</a>.
               <li>Return |workerTiming|'s [=service worker timing info/fetch event dispatch time=].
             </ol>
           </li>

--- a/index.html
+++ b/index.html
@@ -308,16 +308,15 @@
         <ul>
           <li>The `workerStart` getter steps are to perform the following steps:
             <ol>
-              <li>Let |workerTiming| be |this|'s [=service worker timing=].
-              <li>If |workerTiming| is null, then return |this|'s
-              <a data-cite="resource-timing-2#dom-performanceresourcetiming-workerstart">workerStart</a>.
+              <li>Let |workerTiming| be |this|'s [=PerformanceNavigationTiming/service worker timing=].
+              <li>If |workerTiming| is null, then return |this|'s prototype's `workerStart`.
               <li>Return |workerTiming|'s [=service worker timing info/start time=].
             </ol>
           </li>
           <li>The `fetchStart` getter steps are to perform the following steps:
             <ol>
-              <li>Let |workerTiming| be |this|'s [=service worker timing=].
-              <li>If |workerTiming| is null, then return |this|'s `fetchStart`.
+              <li>Let |workerTiming| be |this|'s [=PerformanceNavigationTiming/service worker timing=].
+              <li>If |workerTiming| is null, then return |this|'s prototype's `fetchStart`.
               <li>Return |workerTiming|'s [=service worker timing info/fetch event dispatch time=].
             </ol>
           </li>

--- a/index.html
+++ b/index.html
@@ -314,8 +314,7 @@
               <li>Return |workerTiming|'s [=service worker timing info/start time=].
             </ol>
           </li>
-          <li>The <dfn id='dom-PerformanceNavigationTiming-fetchStart'><code>
-            fetchStart</code></dfn> getter steps are to perform the following steps:
+          <li>The <dfn>`fetchStart` getter steps</dfn> are to perform the following steps:
             <ol>
               <li>Let |workerTiming| be |this|'s [=service worker timing=].
               <li>If |workerTiming| is null, then return |this|'s {{PerformanceResourceTiming/fetchStart}}.

--- a/index.html
+++ b/index.html
@@ -378,8 +378,8 @@
         <p>A <a>PerformanceNavigationTiming</a> has an associated
         {{NavigationType}} <a data-dfn-for="PerformanceNavigationTiming"><dfn>navigation type</dfn></a>.
 
-        <p>A <a>PerformanceNavigationTiming</a> has an associated null or [=service worker timing info=]
-        <a data-dfn-for="PerformanceNavigationTiming"> <dfn>service worker timing</dfn></a>.
+        <p>A {{PerformanceNavigationTiming}} has an associated null or [=service worker timing info=] 
+        <dfn data-dfn-for="PerformanceNavigationTiming">service worker timing</dfn>.
 
         </p>
         <p data-dfn-for='PerformanceNavigationTiming'>

--- a/index.html
+++ b/index.html
@@ -310,7 +310,7 @@
             workerStart</code></dfn> getter steps are to perform the following steps:
             <ol>
               <li>Let |workerTiming| be |this|'s [=service worker timing=].</p>
-              <li>If |workerTiming| is not null, then return [=service worker timing info/start time=].
+              <li>If |workerTiming| is not null, then return |workerTiming|'s [=service worker timing info/start time=].
               <li>Return 0.
             </ol>
           </li>
@@ -318,7 +318,7 @@
             fetchStart</code></dfn> getter steps are to perform the following steps:
             <ol>
               <li>Let |workerTiming| be |this|'s [=service worker timing=].</p>
-              <li>If |workerTiming| is not null, then return [=service worker timing info/fetch event dispatch time=].
+              <li>If |workerTiming| is not null, then return |workerTiming|'s [=service worker timing info/fetch event dispatch time=].
               <li>Return |this|'s {{PerformanceResourceTiming/fetchStart}}.
             </ol>
           </li>

--- a/index.html
+++ b/index.html
@@ -306,8 +306,7 @@
           interface:
         </p>
         <ul>
-          <li>The <dfn for="PerformanceNavigationTiming" id='dom-PerformanceNavigationTiming-workerStart'><code>
-            workerStart</code></dfn> getter steps are to perform the following steps:
+          <li>The `workerStart` getter steps are to perform the following steps:
             <ol>
               <li>Let |workerTiming| be |this|'s [=service worker timing=].
               <li>If |workerTiming| is null, then return |this|'s

--- a/index.html
+++ b/index.html
@@ -564,7 +564,7 @@
         count</a> to |redirectCount|.
         <li>Set |navigationTimingEntry|'s <a data-for="PerformanceNavigationTiming">navigation
         type</a> to |navigationType|.
-        <li>Set |navigationTimingEntry|'s <a data-for="PerformanceNavigationTiming">service worker timing</a>
+        <li>Set |navigationTimingEntry|'s [=PerformanceNavigationTiming/service worker timing=]
         to |serviceWorkerTiming|.
         <li>Set |document|'s <span>navigation timing entry</span> to |navigationTimingEntry|.
         <li>add |navigationTimingEntry| to |global|'s

--- a/index.html
+++ b/index.html
@@ -305,21 +305,21 @@
           "RESOURCE-TIMING-2#dom-performanceresourcetiming">PerformanceResourceTiming</dfn></code>
           interface:
         </p>
-        <ul data-dfn-for="PerformanceResourceTiming">
+        <ul data-dfn-for="PerformanceNavigationTiming">
           <li>The <dfn id='dom-PerformanceNavigationTiming-workerStart'><code>
             workerStart</code></dfn> getter steps are to perform the following steps:
             <ol>
-              <li>Let |workerTiming| be |this|'s [=service worker timing=].</p>
-              <li>If |workerTiming| is not null, then return |workerTiming|'s [=service worker timing info/start time=].
-              <li>Return 0.
+              <li>Let |workerTiming| be |this|'s [=service worker timing=].
+              <li>If |workerTiming| is null, then return 0.
+              <li>Return |workerTiming|'s [=service worker timing info/start time=].
             </ol>
           </li>
           <li>The <dfn id='dom-PerformanceNavigationTiming-fetchStart'><code>
             fetchStart</code></dfn> getter steps are to perform the following steps:
             <ol>
-              <li>Let |workerTiming| be |this|'s [=service worker timing=].</p>
-              <li>If |workerTiming| is not null, then return |workerTiming|'s [=service worker timing info/fetch event dispatch time=].
-              <li>Return |this|'s {{PerformanceResourceTiming/fetchStart}}.
+              <li>Let |workerTiming| be |this|'s [=service worker timing=].
+              <li>If |workerTiming| is null, then return |this|'s {{PerformanceResourceTiming/fetchStart}}.
+              <li>Return |workerTiming|'s [=service worker timing info/fetch event dispatch time=].
             </ol>
           </li>
         </ul>

--- a/index.html
+++ b/index.html
@@ -306,22 +306,21 @@
           interface:
         </p>
         <ul data-dfn-for="PerformanceResourceTiming">
-          <li>The <dfn>initiatorType</dfn> attribute MUST return the
-          {{DOMString}} "<code>navigation</code>".
-          </li>
           <li>The <dfn id='dom-PerformanceNavigationTiming-workerStart'><code>
-            workerStart</code></dfn> attribute MUST return the time immediately
-            before the user agent <a data-cite=
-            "service-workers#run-service-worker">ran the worker</a> (if the
-            <a>current document</a> has an <a data-cite=
-            "service-workers#dfn-containing-service-worker-registration">active
-            service worker registration</a> [[SERVICE-WORKERS]]) required to
-            service the request, or if the worker was already available, the
-            time immediately before the user agent <a data-cite=
-            "service-workers#fetchevent">fired an event named `fetch`</a> at
-            the <a data-cite="service-workers#dfn-active-worker">active
-            worker</a>. Otherwise, if there is no active worker this attribute
-            MUST return zero.
+            workerStart</code></dfn> getter steps are to perform the following steps:
+            <ol>
+              <li>Let |workerTiming| be |this|'s [=service worker timing=].</p>
+              <li>If |workerTiming| is not null, then return [=service worker timing info/start time=].
+              <li>Return 0.
+            </ol>
+          </li>
+          <li>The <dfn id='dom-PerformanceNavigationTiming-fetchStart'><code>
+            fetchStart</code></dfn> getter steps are to perform the following steps:
+            <ol>
+              <li>Let |workerTiming| be |this|'s [=service worker timing=].</p>
+              <li>If |workerTiming| is not null, then return [=service worker timing info/fetch event dispatch time=].
+              <li>Return |this|'s {{PerformanceResourceTiming/fetchStart}}.
+            </ol>
           </li>
         </ul>
         <p class="note">
@@ -370,7 +369,6 @@
         [=document load timing info=] <a data-dfn-for="PerformanceResourceTiming">
         <dfn>document load timing</dfn></a>.
 
-
         <p>A <a>PerformanceNavigationTiming</a> has an associated
         [=document unload timing info=] <a data-dfn-for="PerformanceNavigationTiming">
         <dfn>previous document unload timing</dfn></a>.
@@ -380,6 +378,9 @@
 
         <p>A <a>PerformanceNavigationTiming</a> has an associated
         {{NavigationType}} <a data-dfn-for="PerformanceNavigationTiming"><dfn>navigation type</dfn></a>.
+
+        <p>A <a>PerformanceNavigationTiming</a> has an associated null or [=service worker timing info=]
+        <a data-dfn-for="PerformanceNavigationTiming"> <dfn>service worker timing</dfn></a>.
 
         </p>
         <p data-dfn-for='PerformanceNavigationTiming'>
@@ -546,14 +547,15 @@
       <p data-dfn-for="Document">Each [=document=] has an associated <dfn>navigation timing entry</dfn>, initially unset.
 
       <p>To <dfn export="">create the navigation timing entry</dfn> for {{Document}} |document|,
-      given a [=fetch timing info=] |fetchTiming|, a number |redirectCount|, and a
-      {{NavigationType}} |navigationType|, do the following:
+      given a [=fetch timing info=] |fetchTiming|, a number |redirectCount|, a
+      {{NavigationType}} |navigationType|, and a null or [=service worker timing info=] |serviceWorkerTiming|,
+      do the following:
       <ol>
         <li>Let |global| be |document|'s [=relevant global object=].</li>
         <li>Let |navigationTimingEntry| be a new {{PerformanceNavigationTiming}} object in |global|'s
         [=global object/realm=].
         <li><a data-cite="RESOURCE-TIMING-2#dfn-setup-the-resource-timing-entry">Setup the resource
-        timing entry=] for |navigationTimingEntry| given "<code>navigation</code>", |document|'s
+        timing entry</a> for |navigationTimingEntry| given "<code>navigation</code>", |document|'s
         <a data-cite="HTML#the-document's-address">address</a>, and |fetchTiming|.
         <li>Set |navigationTimingEntry|'s <a data-for="PerformanceNavigationTiming">document load
         timing</a> to |document|'s [=Document/load timing info=]
@@ -563,6 +565,8 @@
         count</a> to |redirectCount|.
         <li>Set |navigationTimingEntry|'s <a data-for="PerformanceNavigationTiming">navigation
         type</a> to |navigationType|.
+        <li>Set |navigationTimingEntry|'s <a data-for="PerformanceNavigationTiming">service worker timing</a>
+        to |serviceWorkerTiming|.
         <li>Set |document|'s <span>navigation timing entry</span> to |navigationTimingEntry|.
         <li>add |navigationTimingEntry| to |global|'s
         <a data-cite='performance-timeline-2#dfn-performance-entry-buffer'>performance entry buffer</a>.


### PR DESCRIPTION
Depends on https://github.com/w3c/ServiceWorker/pull/1575

closes https://github.com/w3c/navigation-timing/issues/134


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/navigation-timing/pull/143.html" title="Last updated on May 18, 2021, 7:00 AM UTC (8030dde)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/navigation-timing/143/ab8c184...8030dde.html" title="Last updated on May 18, 2021, 7:00 AM UTC (8030dde)">Diff</a>