### PR TITLE
Add a landing attribute to PerformanceNavigationTiming

### DIFF
--- a/index.html
+++ b/index.html
@@ -379,6 +379,7 @@
             readonly        attribute DOMHighResTimeStamp loadEventEnd;
             readonly        attribute NavigationType      type;
             readonly        attribute unsigned short      redirectCount;
+            readonly        attribute boolean             landing;
             [Default] object toJSON();
         };
         </pre>
@@ -474,6 +475,15 @@
         </p>
         <p class="note">This timestamp is measured after the user agent completes handling the
           <a data-cite="HTML/parsing.html#the-end:event-event-load">load</a> event for the document.
+        </p>
+        <p data-dfn-for='PerformanceNavigationTiming'>
+          The <dfn>landing</dfn> getter steps are as following:
+          <ul>
+            <li><p>Let |document| be |this|'s [=relevant global object=]'s [=associated Document=].</p></li>
+            <li><p>Let |history entry| be |document|'s [=browsing context=]'s [=session history=]'s first entry.</p></li>
+            <li><p>If |history entry|'s [=session history entry/document=] equals |document|, return true.</p></li>
+            <li><p>Return false.</p></li> 
+          </ul>
         </p>
         <p data-dfn-for='PerformanceNavigationTiming'>
          The <dfn>type</dfn> getter steps are to run the |this|'s [=navigation type=].


### PR DESCRIPTION
This is a PR to demonstrate what defining a landing attribute could look like. This is not necessarily how we want the definition to land, as some concepts it relies on are not yet exported.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoavweiss/navigation-timing/pull/161.html" title="Last updated on Sep 30, 2021, 11:34 AM UTC (c9b3dd1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/navigation-timing/161/8b93d0a...yoavweiss:c9b3dd1.html" title="Last updated on Sep 30, 2021, 11:34 AM UTC (c9b3dd1)">Diff</a>