### PR TITLE
Hide redirectStart and redirectEnd for navigations with cross-origin redirects

### DIFF
--- a/index.html
+++ b/index.html
@@ -285,14 +285,14 @@
         <ul>
           <li>The {{PerformanceResourceTiming/redirectStart}} getter steps are to perform the following steps:
             <ol>
-              <li>If |this|'s [=PerformanceNavigationTiming/has cross origin redirects] is true, return 0.
+              <li>If |this|'s [=PerformanceNavigationTiming/redirect count] is 0, return 0.
               <li>Otherwise return |this|'s {{PerformanceResourceTiming/redirectStart}}.
             </ol>
           </li>
           <li>The {{PerformanceResourceTiming/redirectEnd}} getter steps are to perform the following steps:
             <ol>
-              <li>If |this|'s [=PerformanceNavigationTiming/has cross origin redirects] is true, return 0.
-              <li>Otherwise return |this|'s {{PerformanceResourceTiming/redirectEnd}}.
+              <li>If |this|'s [=PerformanceNavigationTiming/redirect count] is 0, return 0.
+                <li>Otherwise return |this|'s {{PerformanceResourceTiming/redirectEnd}}.
             </ol>
             <p class="note">
               Though `redirectStart` and `redirectEnd` are exposed in <a data-cite=
@@ -388,9 +388,6 @@
 
         <p>A <a>PerformanceNavigationTiming</a> has an associated
         number <a data-dfn-for="PerformanceNavigationTiming"><dfn>redirect count</dfn></a>.
-
-        <p>A <a>PerformanceNavigationTiming</a> has an associated
-        boolean <a data-dfn-for="PerformanceNavigationTiming"><dfn>has cross-origin redirects</dfn></a>.
 
         <p>A <a>PerformanceNavigationTiming</a> has an associated
         {{NavigationType}} <a data-dfn-for="PerformanceNavigationTiming"><dfn>navigation type</dfn></a>.
@@ -588,8 +585,8 @@
 
       <p>To <dfn data-export="">create the navigation timing entry</dfn> for {{Document}} |document|,
       given a [=fetch timing info=] |fetchTiming|, a number |redirectCount|, a
-      {{NavigationType}} |navigationType|, a null or [=service worker timing info=] |serviceWorkerTiming|,
-      and a boolean |hasCrossOriginRedirects|, do the following:
+      {{NavigationType}} |navigationType|, and a null or [=service worker timing info=] |serviceWorkerTiming|,
+      do the following:
       <ol>
         <li>Let |global| be |document|'s [=relevant global object=].</li>
         <li>Let |navigationTimingEntry| be a new {{PerformanceNavigationTiming}} object in |global|'s
@@ -607,8 +604,6 @@
         type</a> to |navigationType|.
         <li>Set |navigationTimingEntry|'s [=PerformanceNavigationTiming/service worker timing=]
         to |serviceWorkerTiming|.
-        <li>Set |navigationTimingEntry|'s <a data-for="PerformanceNavigationTiming">has cross-origin redirects</a>
-        to |hasCrossOriginRedirects|.
         <li>Set |document|'s <span>navigation timing entry</span> to |navigationTimingEntry|.
         <li>add |navigationTimingEntry| to |global|'s
         <a data-cite='performance-timeline-2#dfn-performance-entry-buffer'>performance entry buffer</a>.

--- a/index.html
+++ b/index.html
@@ -283,6 +283,24 @@
           interface:
         </p>
         <ul>
+          <li>The {{PerformanceResourceTiming/redirectStart}} getter steps are to perform the following steps:
+            <ol>
+              <li>If |this|'s [=PerformanceNavigationTiming/has cross origin redirects] is true, return 0.
+              <li>Otherwise return |this|'s {{PerformanceResourceTiming/redirectStart}}.
+            </ol>
+          </li>
+          <li>The {{PerformanceResourceTiming/redirectEnd}} getter steps are to perform the following steps:
+            <ol>
+              <li>If |this|'s [=PerformanceNavigationTiming/has cross origin redirects] is true, return 0.
+              <li>Otherwise return |this|'s {{PerformanceResourceTiming/redirectEnd}}.
+            </ol>
+            <p class="note">
+              Though `redirectStart` and `redirectEnd` are exposed in <a data-cite=
+              "RESOURCE-TIMING-2#dom-performanceresourcetiming">PerformanceResourceTiming</a>, it
+              has a different meaning in Navigation Timing, which returns zero for navigations with
+              cross-origin redirects.
+            </p>
+          </li>
           <li>The {{PerformanceResourceTiming/workerStart}} getter steps are to perform the following steps:
             <ol>
               <li>Let |workerTiming| be |this|'s [=PerformanceNavigationTiming/service worker timing=].
@@ -370,6 +388,9 @@
 
         <p>A <a>PerformanceNavigationTiming</a> has an associated
         number <a data-dfn-for="PerformanceNavigationTiming"><dfn>redirect count</dfn></a>.
+
+        <p>A <a>PerformanceNavigationTiming</a> has an associated
+        boolean <a data-dfn-for="PerformanceNavigationTiming"><dfn>has cross-origin redirects</dfn></a>.
 
         <p>A <a>PerformanceNavigationTiming</a> has an associated
         {{NavigationType}} <a data-dfn-for="PerformanceNavigationTiming"><dfn>navigation type</dfn></a>.
@@ -567,8 +588,8 @@
 
       <p>To <dfn data-export="">create the navigation timing entry</dfn> for {{Document}} |document|,
       given a [=fetch timing info=] |fetchTiming|, a number |redirectCount|, a
-      {{NavigationType}} |navigationType|, and a null or [=service worker timing info=] |serviceWorkerTiming|,
-      do the following:
+      {{NavigationType}} |navigationType|, a null or [=service worker timing info=] |serviceWorkerTiming|,
+      and a boolean |hasCrossOriginRedirects|, do the following:
       <ol>
         <li>Let |global| be |document|'s [=relevant global object=].</li>
         <li>Let |navigationTimingEntry| be a new {{PerformanceNavigationTiming}} object in |global|'s
@@ -586,6 +607,8 @@
         type</a> to |navigationType|.
         <li>Set |navigationTimingEntry|'s [=PerformanceNavigationTiming/service worker timing=]
         to |serviceWorkerTiming|.
+        <li>Set |navigationTimingEntry|'s <a data-for="PerformanceNavigationTiming">has cross-origin redirects</a>
+        to |hasCrossOriginRedirects|.
         <li>Set |document|'s <span>navigation timing entry</span> to |navigationTimingEntry|.
         <li>add |navigationTimingEntry| to |global|'s
         <a data-cite='performance-timeline-2#dfn-performance-entry-buffer'>performance entry buffer</a>.

--- a/index.html
+++ b/index.html
@@ -296,8 +296,8 @@
             </ol>
             <p class="note">
               Though `redirectStart` and `redirectEnd` are exposed in <a data-cite=
-              "RESOURCE-TIMING-2#dom-performanceresourcetiming">PerformanceResourceTiming</a>, it
-              has a different meaning in Navigation Timing, which returns zero for navigations with
+              "RESOURCE-TIMING-2#dom-performanceresourcetiming">PerformanceResourceTiming</a>, they
+              have a different meaning in Navigation Timing, where they return zero for navigations with
               cross-origin redirects.
             </p>
           </li>


### PR DESCRIPTION
Closes https://github.com/whatwg/html/issues/7104


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/navigation-timing/pull/170.html" title="Last updated on Feb 24, 2022, 9:29 AM UTC (50f595c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/navigation-timing/170/0f2807d...50f595c.html" title="Last updated on Feb 24, 2022, 9:29 AM UTC (50f595c)">Diff</a>