### PR TITLE
Pass response body info through

### DIFF
--- a/index.html
+++ b/index.html
@@ -585,15 +585,15 @@
 
       <p>To <dfn data-export="">create the navigation timing entry</dfn> for {{Document}} |document|,
       given a [=fetch timing info=] |fetchTiming|, a number |redirectCount|, a
-      {{NavigationTimingType}} |navigationType|, and a null or [=service worker timing info=] |serviceWorkerTiming|,
-      do the following:
+      {{NavigationTimingType}} |navigationType|, a null or [=service worker timing info=] |serviceWorkerTiming|, and a
+      [=fetch resource info=] |resourceInfo|, do the following:
       <ol>
         <li>Let |global| be |document|'s [=relevant global object=].</li>
         <li>Let |navigationTimingEntry| be a new {{PerformanceNavigationTiming}} object in |global|'s
         [=global object/realm=].
         <li><a data-cite="RESOURCE-TIMING-2#dfn-setup-the-resource-timing-entry">Setup the resource
         timing entry</a> for |navigationTimingEntry| given "<code>navigation</code>", |document|'s
-        <a data-cite="HTML#the-document's-address">address</a>, and |fetchTiming|.
+        <a data-cite="HTML#the-document's-address">address</a>, |fetchTiming|, .
         <li>Set |navigationTimingEntry|'s <a data-for="PerformanceNavigationTiming">document load
         timing</a> to |document|'s [=Document/load timing info=]
         <li>Set |navigationTimingEntry|'s <a data-for="PerformanceNavigationTiming">previous

--- a/index.html
+++ b/index.html
@@ -585,15 +585,16 @@
 
       <p>To <dfn data-export="">create the navigation timing entry</dfn> for {{Document}} |document|,
       given a [=fetch timing info=] |fetchTiming|, a number |redirectCount|, a
-      {{NavigationTimingType}} |navigationType|, a null or [=service worker timing info=] |serviceWorkerTiming|, and a
-      [=fetch resource info=] |resourceInfo|, do the following:
+      {{NavigationTimingType}} |navigationType|, a null or [=service worker timing info=] |serviceWorkerTiming|,
+      a DOMString |cacheMode|, and a [=fetch resource info=] |resourceInfo|, do the following:
       <ol>
         <li>Let |global| be |document|'s [=relevant global object=].</li>
         <li>Let |navigationTimingEntry| be a new {{PerformanceNavigationTiming}} object in |global|'s
         [=global object/realm=].
         <li><a data-cite="RESOURCE-TIMING-2#dfn-setup-the-resource-timing-entry">Setup the resource
         timing entry</a> for |navigationTimingEntry| given "<code>navigation</code>", |document|'s
-        <a data-cite="HTML#the-document's-address">address</a>, |fetchTiming|, .
+        <a data-cite="HTML#the-document's-address">address</a>, |fetchTiming|, |cacheMode|, and
+        |resourceInfo|.
         <li>Set |navigationTimingEntry|'s <a data-for="PerformanceNavigationTiming">document load
         timing</a> to |document|'s [=Document/load timing info=]
         <li>Set |navigationTimingEntry|'s <a data-for="PerformanceNavigationTiming">previous

--- a/index.html
+++ b/index.html
@@ -586,7 +586,7 @@
       <p>To <dfn data-export="">create the navigation timing entry</dfn> for {{Document}} |document|,
       given a [=fetch timing info=] |fetchTiming|, a number |redirectCount|, a
       {{NavigationTimingType}} |navigationType|, a null or [=service worker timing info=] |serviceWorkerTiming|,
-      a DOMString |cacheMode|, and a [=fetch resource info=] |resourceInfo|, do the following:
+      a DOMString |cacheMode|, and a [=response body info=] |bodyInfo|, do the following:
       <ol>
         <li>Let |global| be |document|'s [=relevant global object=].</li>
         <li>Let |navigationTimingEntry| be a new {{PerformanceNavigationTiming}} object in |global|'s
@@ -594,7 +594,7 @@
         <li><a data-cite="RESOURCE-TIMING-2#dfn-setup-the-resource-timing-entry">Setup the resource
         timing entry</a> for |navigationTimingEntry| given "<code>navigation</code>", |document|'s
         <a data-cite="HTML#the-document's-address">address</a>, |fetchTiming|, |cacheMode|, and
-        |resourceInfo|.
+        |bodyInfo|.
         <li>Set |navigationTimingEntry|'s <a data-for="PerformanceNavigationTiming">document load
         timing</a> to |document|'s [=Document/load timing info=]
         <li>Set |navigationTimingEntry|'s <a data-for="PerformanceNavigationTiming">previous


### PR DESCRIPTION
As part of https://github.com/whatwg/fetch/pull/1413
`encoded body size` and `decoded body size` are no longer part of `timing info` and need to be passed separately, as unlike the rest of `fetch timing info` they do get stored with the response.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/navigation-timing/pull/176.html" title="Last updated on May 26, 2022, 12:58 PM UTC (53dcb24)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/navigation-timing/176/5bf6f76...53dcb24.html" title="Last updated on May 26, 2022, 12:58 PM UTC (53dcb24)">Diff</a>