### PR TITLE
Navigation timing name should be the initial URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -248,9 +248,6 @@
           attributes of {{PerformanceEntry}} interface:
         </p>
         <ul>
-          <li>The <code>name</code>
-          getter steps are to return the [=current document=]'s {{Document/URL}}.
-          </li>
           <li>The <code>entryType</code>
           getter step is to return the {{DOMString}} "<code id="perf-navigation">navigation</code>".
           </li>
@@ -593,8 +590,7 @@
         [=global object/realm=].
         <li><a data-cite="RESOURCE-TIMING-2#dfn-setup-the-resource-timing-entry">Setup the resource
         timing entry</a> for |navigationTimingEntry| given "<code>navigation</code>", |document|'s
-        <a data-cite="HTML#the-document's-address">address</a>, |fetchTiming|, |cacheMode|, and
-        |bodyInfo|.
+        {{Document/URL}}, |fetchTiming|, |cacheMode|, and |bodyInfo|.
         <li>Set |navigationTimingEntry|'s <a data-for="PerformanceNavigationTiming">document load
         timing</a> to |document|'s [=Document/load timing info=]
         <li>Set |navigationTimingEntry|'s <a data-for="PerformanceNavigationTiming">previous


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/navigation-timing/pull/182.html" title="Last updated on Sep 7, 2022, 12:38 PM UTC (6eb3bdf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/navigation-timing/182/8716ea0...6eb3bdf.html" title="Last updated on Sep 7, 2022, 12:38 PM UTC (6eb3bdf)">Diff</a>