### PR TITLE
Add criticalCHRestartOccured

### DIFF
--- a/index.html
+++ b/index.html
@@ -371,6 +371,7 @@
             readonly        attribute DOMHighResTimeStamp  loadEventEnd;
             readonly        attribute NavigationTimingType type;
             readonly        attribute unsigned short       redirectCount;
+            readonly        attribute boolean              criticalCHRestartOccured;
             [Default] object toJSON();
         };
         </pre>
@@ -388,6 +389,9 @@
 
         <p>A <a>PerformanceNavigationTiming</a> has an associated
         {{NavigationTimingType}} <a data-dfn-for="PerformanceNavigationTiming"><dfn>navigation type</dfn></a>.
+
+        <p>A <a>PerformanceNavigationTiming</a> has an associated
+          boolean <a data-dfn-for="PerformanceNavigationTiming"><dfn>critical ch restart occured</dfn></a>.
 
         <p>A {{PerformanceNavigationTiming}} has an associated null or [=service worker timing info=] 
         <dfn data-dfn-for="PerformanceNavigationTiming">service worker timing</dfn>.
@@ -487,6 +491,10 @@
          The <dfn>redirectCount</dfn> getter steps are to return |this|'s
          <span>redirect count</span>.</p>
         </p>
+        <p data-dfn-for='PerformanceNavigationTiming'>
+          The <dfn>criticalCHRestartOccured</dfn> getter steps are to return |this|'s
+         <span>critical ch restart occured</span>.</p>
+         </p>
         <p>
           The <dfn>toJSON()</dfn> method runs the [=default toJSON steps=] for [=this=].
         </p>
@@ -579,7 +587,7 @@
       <p>To <dfn data-export="">create the navigation timing entry</dfn> for {{Document}} |document|,
       given a [=fetch timing info=] |fetchTiming|, a number |redirectCount|, a
       {{NavigationTimingType}} |navigationType|, a null or [=service worker timing info=] |serviceWorkerTiming|,
-      a DOMString |cacheMode|, and a [=response body info=] |bodyInfo|, do the following:
+      a DOMString |cacheMode|, a boolean |criticalCHRestartOccured|, and a [=response body info=] |bodyInfo|, do the following:
       <ol>
         <li>Let |global| be |document|'s [=relevant global object=].</li>
         <li>Let |navigationTimingEntry| be a new {{PerformanceNavigationTiming}} object in |global|'s
@@ -598,6 +606,8 @@
         <li>Set |navigationTimingEntry|'s [=PerformanceNavigationTiming/service worker timing=]
         to |serviceWorkerTiming|.
         <li>Set |document|'s <span>navigation timing entry</span> to |navigationTimingEntry|.
+        <li>Set |navigationTimingEntry|'s <a data-for="PerformanceNavigationTiming">critical
+          ch restart occured</a> to |criticalCHRestartOccured|.
         <li>add |navigationTimingEntry| to |global|'s
         <a data-cite='performance-timeline-2#dfn-performance-entry-buffer'>performance entry buffer</a>.
       </ol>


### PR DESCRIPTION
Website can indicate that a particular Client Hint is critical to the page by including it in a `Critical-CH` HTTP response header. Doing so will trigger a connection restart if the hint listed in the `Critical-CH` HTTP response header could be (but wasn't) included in the HTTP request initially sent. We should indicate this has happened in Navigation Timing so that developers can know if a restart occurred and impacted timing.

We can pull this from the [navigable](https://wicg.github.io/client-hints-infrastructure/#has-reloaded-for-critical-ch) but I'm not quite sure if this is the right way to thread it.

Closes #177