### PR TITLE
Add notRestoredReasons to PerformanceNavigationTiming attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -623,8 +623,8 @@
         <li>Set |navigationTimingEntry|'s <a data-for="PerformanceNavigationTiming">`Critical-CH` restart time</a>
         to |criticalCHRestart|.
         <li> Set |navigationTimingEntry|'s [=PerformanceNavigationTiming/not restored reasons=]
-        to the result of [=create a notrestoredreasons object=] given |document|'s
-        [=Document/not restored reasons=].</li>
+        to the result of <a data-lt="create a notrestoredreasons object">creating a
+        NotRestoredReasons object</a> given |document|'s [=Document/not restored reasons=].</li>
         <li>add |navigationTimingEntry| to |global|'s
         <a data-cite='performance-timeline-2#dfn-performance-entry-buffer'>performance entry buffer</a>.
       </ol>

--- a/index.html
+++ b/index.html
@@ -624,8 +624,8 @@
         to |criticalCHRestart|.
         <li>If |document| is the outermost main frame's document, set |navigationTimingEntry|'s
         <a data-for="PerformanceNavigationTiming">not restored reasons</a> to the result of
-        creating a NotRestoredReasons object given |document|'s node navigable's active[=session
-        history entry=]'s document state's not restored reasons and |global|'s
+        creating a NotRestoredReasons object given |document|'s node navigable's active session
+        history entry's document state's not restored reasons and |global|'s
         [=global object/realm=].</li>
         <li>add |navigationTimingEntry| to |global|'s
         <a data-cite='performance-timeline-2#dfn-performance-entry-buffer'>performance entry buffer</a>.

--- a/index.html
+++ b/index.html
@@ -372,6 +372,7 @@
             readonly        attribute NavigationTimingType type;
             readonly        attribute unsigned short       redirectCount;
             readonly        attribute DOMHighResTimeStamp  criticalCHRestart;
+            readonly        attribute NotRestoredReasons?  notRestoredReasons;
             [Default] object toJSON();
         };
         </pre>
@@ -392,6 +393,9 @@
 
         <p>A <a>PerformanceNavigationTiming</a> has an associated
           {{DOMHighResTimeStamp}} <a data-dfn-for="PerformanceNavigationTiming"><dfn>`Critical-CH` restart time</dfn></a>.
+
+        <p>A <a>PerformanceNavigationTiming</a> has an associated
+        {{NotRestoredReasons}} <a data-dfn-for="PerformanceNavigationTiming"><dfn>not restored reasons</dfn></a>.
 
         <p>A {{PerformanceNavigationTiming}} has an associated null or [=service worker timing info=] 
         <dfn data-dfn-for="PerformanceNavigationTiming">service worker timing</dfn>.

--- a/index.html
+++ b/index.html
@@ -622,9 +622,8 @@
         <li>Set |document|'s <span>navigation timing entry</span> to |navigationTimingEntry|.
         <li>Set |navigationTimingEntry|'s <a data-for="PerformanceNavigationTiming">`Critical-CH` restart time</a>
         to |criticalCHRestart|.
-        <li>If |document|'s [=Document/not restored reasons=] is not null, then set
-        |navigationTimingEntry|'s [=PerformanceNavigationTiming/not restored reasons=] to the
-        result of [=creating a NotRestoredReasons object=] given |document|'s
+        <li> Set |navigationTimingEntry|'s [=PerformanceNavigationTiming/not restored reasons=]
+        to the result of [=creating a NotRestoredReasons object=] given |document|'s
         [=Document/not restored reasons=].</li>
         <li>add |navigationTimingEntry| to |global|'s
         <a data-cite='performance-timeline-2#dfn-performance-entry-buffer'>performance entry buffer</a>.

--- a/index.html
+++ b/index.html
@@ -625,8 +625,7 @@
         <li>If |document| is the outermost main frame's document, set |navigationTimingEntry|'s
         <a data-for="PerformanceNavigationTiming">not restored reasons</a> to the result of
         creating a NotRestoredReasons object given |document|'s node navigable's active session
-        history entry's document state's not restored reasons and |global|'s
-        [=global object/realm=].</li>
+        history entry's document state's not restored reasons and realm.</li>
         <li>add |navigationTimingEntry| to |global|'s
         <a data-cite='performance-timeline-2#dfn-performance-entry-buffer'>performance entry buffer</a>.
       </ol>

--- a/index.html
+++ b/index.html
@@ -622,7 +622,7 @@
         <li>Set |document|'s <span>navigation timing entry</span> to |navigationTimingEntry|.
         <li>Set |navigationTimingEntry|'s <a data-for="PerformanceNavigationTiming">`Critical-CH` restart time</a>
         to |criticalCHRestart|.
-        <li>If |document| is the outermost main frame's document, set |navigationTimingEntry|'s
+        <li>If document is the outermost main frame's document, set |navigationTimingEntry|'s
         <a data-for="PerformanceNavigationTiming">not restored reasons</a> to the result of
         creating a NotRestoredReasons object given |document|'s node navigable's active session
         history entry's document state's not restored reasons and realm.</li>

--- a/index.html
+++ b/index.html
@@ -622,10 +622,10 @@
         <li>Set |document|'s <span>navigation timing entry</span> to |navigationTimingEntry|.
         <li>Set |navigationTimingEntry|'s <a data-for="PerformanceNavigationTiming">`Critical-CH` restart time</a>
         to |criticalCHRestart|.
-        <li>If document is the outermost main frame's document, set |navigationTimingEntry|'s
-        <a data-for="PerformanceNavigationTiming">not restored reasons</a> to the result of
-        creating a NotRestoredReasons object given |document|'s node navigable's active session
-        history entry's document state's not restored reasons and realm.</li>
+        <li>If |document|'s [=Document/not restored reasons=] is not null, then set
+        |navigationTimingEntry|'s [=PerformanceNavigationTiming/not restored reasons=] to the
+        result of [=creating a NotRestoredReasons object=] given |document|'s
+        [=Document/not restored reasons=].</li>
         <li>add |navigationTimingEntry| to |global|'s
         <a data-cite='performance-timeline-2#dfn-performance-entry-buffer'>performance entry buffer</a>.
       </ol>

--- a/index.html
+++ b/index.html
@@ -623,7 +623,7 @@
         <li>Set |navigationTimingEntry|'s <a data-for="PerformanceNavigationTiming">`Critical-CH` restart time</a>
         to |criticalCHRestart|.
         <li> Set |navigationTimingEntry|'s [=PerformanceNavigationTiming/not restored reasons=]
-        to the result of [=creating a NotRestoredReasons object=] given |document|'s
+        to the result of [=creating a notrestoredreasons object=] given |document|'s
         [=Document/not restored reasons=].</li>
         <li>add |navigationTimingEntry| to |global|'s
         <a data-cite='performance-timeline-2#dfn-performance-entry-buffer'>performance entry buffer</a>.

--- a/index.html
+++ b/index.html
@@ -506,6 +506,9 @@
             the moment the redirection part of the navigation was restarted.
           </p>
         </div>
+        <p data-dfn-for='PerformanceNavigationTiming'>
+         The <dfn>notRestoredReasons</dfn> getter steps are to return |this|'s
+        <span>not restored reasons</span>.</p>
         <p>
           The <dfn>toJSON()</dfn> method runs the [=default toJSON steps=] for [=this=].
         </p>
@@ -619,6 +622,10 @@
         <li>Set |document|'s <span>navigation timing entry</span> to |navigationTimingEntry|.
         <li>Set |navigationTimingEntry|'s <a data-for="PerformanceNavigationTiming">`Critical-CH` restart time</a>
         to |criticalCHRestart|.
+        <li>Set |navigationTimingEntry|'s <a data-for="PerformanceNavigationTiming">not restored
+        reasons</a> to the result of creating a NotRestoredReasons object given |document|'s
+        node navigable's active session history entry's document state's not restored reasons
+        and realm.</li>
         <li>add |navigationTimingEntry| to |global|'s
         <a data-cite='performance-timeline-2#dfn-performance-entry-buffer'>performance entry buffer</a>.
       </ol>

--- a/index.html
+++ b/index.html
@@ -622,10 +622,10 @@
         <li>Set |document|'s <span>navigation timing entry</span> to |navigationTimingEntry|.
         <li>Set |navigationTimingEntry|'s <a data-for="PerformanceNavigationTiming">`Critical-CH` restart time</a>
         to |criticalCHRestart|.
-        <li>Set |navigationTimingEntry|'s <a data-for="PerformanceNavigationTiming">not restored
-        reasons</a> to the result of creating a NotRestoredReasons object given |document|'s
-        node navigable's active session history entry's document state's not restored reasons
-        and realm.</li>
+        <li>If |document| is the outermost main frame's document, set |navigationTimingEntry|'s
+        <a data-for="PerformanceNavigationTiming">not restored reasons</a> to the result of
+        creating a NotRestoredReasons object given |document|'s node navigable's active session
+        history entry's document state's not restored reasons and realm.</li>
         <li>add |navigationTimingEntry| to |global|'s
         <a data-cite='performance-timeline-2#dfn-performance-entry-buffer'>performance entry buffer</a>.
       </ol>

--- a/index.html
+++ b/index.html
@@ -624,8 +624,9 @@
         to |criticalCHRestart|.
         <li>If |document| is the outermost main frame's document, set |navigationTimingEntry|'s
         <a data-for="PerformanceNavigationTiming">not restored reasons</a> to the result of
-        creating a NotRestoredReasons object given |document|'s node navigable's active session
-        history entry's document state's not restored reasons and realm.</li>
+        creating a NotRestoredReasons object given |document|'s node navigable's active[=session
+        history entry=]'s document state's not restored reasons and |global|'s
+        [=global object/realm=].</li>
         <li>add |navigationTimingEntry| to |global|'s
         <a data-cite='performance-timeline-2#dfn-performance-entry-buffer'>performance entry buffer</a>.
       </ol>

--- a/index.html
+++ b/index.html
@@ -623,7 +623,7 @@
         <li>Set |navigationTimingEntry|'s <a data-for="PerformanceNavigationTiming">`Critical-CH` restart time</a>
         to |criticalCHRestart|.
         <li> Set |navigationTimingEntry|'s [=PerformanceNavigationTiming/not restored reasons=]
-        to the result of [=creating a notrestoredreasons object=] given |document|'s
+        to the result of [=create a notrestoredreasons object=] given |document|'s
         [=Document/not restored reasons=].</li>
         <li>add |navigationTimingEntry| to |global|'s
         <a data-cite='performance-timeline-2#dfn-performance-entry-buffer'>performance entry buffer</a>.


### PR DESCRIPTION
This PR adds notRestoredReasons as a new attribute of PerformanceNavigationTiming.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rubberyuzu/navigation-timing/pull/195.html" title="Last updated on Mar 4, 2024, 5:49 AM UTC (c506661)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/navigation-timing/195/2aa2a3a...rubberyuzu:c506661.html" title="Last updated on Mar 4, 2024, 5:49 AM UTC (c506661)">Diff</a>