### PR TITLE
Use correct ref for queuing

### DIFF
--- a/index.html
+++ b/index.html
@@ -620,7 +620,7 @@
       </ol>
 
       <p>To <dfn data-export="">queue the navigation timing entry</dfn> for {{Document}} |document|,
-      <a data-cite='performance-timeline-2#dfn-queue-a-performanceentry'>queue</a> |document|'s
+      <a data-lt="queue a navigation performanceentry">queue</a> |document|'s
       [=navigation timing entry=].
     </section>
 


### PR DESCRIPTION
Closes w3c/performance-timeline#209


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 502 Bad Gateway :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Feb 1, 2024, 12:43 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fnavigation-timing%2Fb49e7df59a172e63730ff4f574b96e7d059ea750%2Findex.html%3FisPreview%3Dtrue)

```
error code: 502
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/navigation-timing%23196.)._
</details>
