### PR TITLE
Remove references to "prerender"

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,9 +114,6 @@
         </li>
         <li>support for [[HR-TIME-2]];
         </li>
-        <li>support for <a data-cite="resource-hints#prerender">prerender</a>
-        navigations [[RESOURCE-HINTS]];
-        </li>
         <li>exposes <a data-lt=
         'PerformanceNavigationTiming.redirectCount'>number of redirects</a>
         since the last non-redirect navigation;
@@ -520,8 +517,7 @@
             enum NavigationTimingType {
                 "navigate",
                 "reload",
-                "back_forward",
-                "prerender"
+                "back_forward"
             };
           </pre>
           <p>
@@ -536,9 +532,7 @@
               <a data-cite="HTML/browsing-the-web.html#history-handling-behavior">history handling behavior</a>
               is set to
               <a data-cite="HTML/browsing-the-web.html#hh-default">"default"</a>
-              or <a data-cite="HTML/browsing-the-web.html#hh-replace">"replace"</a>
-              and the navigation was not initiated by a <a data-cite=
-              'resource-hints#prerender'>prerender</a> hint [[RESOURCE-HINTS]].
+              or <a data-cite="HTML/browsing-the-web.html#hh-replace">"replace"</a>.
             </dd>
             <dt>
               <dfn>reload</dfn>
@@ -553,13 +547,6 @@
             <dd>
               Navigation that's <a
               data-cite="HTML/browsing-the-web.html#apply-the-history-step">applied from history</a>.
-            </dd>
-            <dt>
-              <dfn>prerender</dfn>
-            </dt>
-            <dd>
-              Navigation initiated by a <a data-cite=
-              'resource-hints#prerender'>prerender</a> hint [[RESOURCE-HINTS]].
             </dd>
           </dl>
           <p class="note">


### PR DESCRIPTION
Fixes #185

`prerender`  navigation type was only ever supported by Chrome and this [was dropped in Chrome 63](https://developer.chrome.com/blog/nostate-prefetch).

It's successor, Speculation Rules, does not use this type [as there is overlap with other types](https://github.com/w3c/navigation-timing/issues/185#issuecomment-1487835055). Some people assume that Speculation Rules does use this. So let's clean it up to avoid that confusion.